### PR TITLE
Upgrade to phpstan v2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,6 +2,6 @@
     "name": "craftcms/phpstan",
     "description": "PHPStan configuration for Craft CMS projects",
     "require": {
-        "phpstan/phpstan": "^1.4.6"
+        "phpstan/phpstan": "^2.1"
     }
 }

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,7 +1,6 @@
 parameters:
     excludePaths:
         - ../cms/src/test/internal/*
-        - ../cms/src/config/composer-classes.php
         - ../cms/src/config/mimeTypes.php
         - ../cms/src/views/debug/*
     scanFiles:


### PR DESCRIPTION
### Description

PHPStan is at v2 now - https://github.com/phpstan/phpstan-src/blob/2.0.x/UPGRADING.md

This PR makes the update, and removes an exclude path which doesn't seem to be valid anyhmore.

This is likely going to be a breaking change for anyway who runs `composer update` and relies on craftcms' phpstan dev-main.

### Related issues

N/A